### PR TITLE
feat: oauth 1단계 구현

### DIFF
--- a/BE/build.gradle
+++ b/BE/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'mysql:mysql-connector-java'

--- a/BE/src/main/java/louie/hanse/issuetracker/oauth/GithubAccessToken.java
+++ b/BE/src/main/java/louie/hanse/issuetracker/oauth/GithubAccessToken.java
@@ -1,0 +1,18 @@
+package louie.hanse.issuetracker.oauth;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+@Getter
+public class GithubAccessToken {
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("scope")
+    private String scope;
+}

--- a/BE/src/main/java/louie/hanse/issuetracker/oauth/GithubAccessTokenRequest.java
+++ b/BE/src/main/java/louie/hanse/issuetracker/oauth/GithubAccessTokenRequest.java
@@ -1,0 +1,15 @@
+package louie.hanse.issuetracker.oauth;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@RequiredArgsConstructor
+@Getter
+public class GithubAccessTokenRequest {
+    private final String clientId;
+    private final String clientSecret;
+    private final String code;
+}

--- a/BE/src/main/java/louie/hanse/issuetracker/oauth/GithubUser.java
+++ b/BE/src/main/java/louie/hanse/issuetracker/oauth/GithubUser.java
@@ -1,0 +1,13 @@
+package louie.hanse.issuetracker.oauth;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.ToString;
+
+@ToString
+public class GithubUser {
+    @JsonProperty("login")
+    private String userName;
+
+    @JsonProperty("avatar_url")
+    private String avatarImageURL;
+}

--- a/BE/src/main/java/louie/hanse/issuetracker/oauth/LoginController.java
+++ b/BE/src/main/java/louie/hanse/issuetracker/oauth/LoginController.java
@@ -1,0 +1,60 @@
+package louie.hanse.issuetracker.oauth;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.net.URI;
+
+@RestController
+@Slf4j
+public class LoginController {
+
+
+    private final String CLIENT_ID = "2e27ae458bb2d6e9f6cb";
+    private final String CALLBACK_URL = "http://localhost:8080/login/callback";
+    private final String CLIENT_SECRET = "135a542b437cdb1cb39401958e209fca297a8695";
+    private final String ACCESS_TOKEN_API_URL = "https://github.com/login/oauth/access_token";
+    private final String ACCESS_SCOPE = "user";
+
+    @GetMapping("/login")
+    public ResponseEntity loginForm(){
+        return ResponseEntity.status(HttpStatus.SEE_OTHER)
+                .location(URI.create("https://github.com/login/oauth/authorize?client_id="
+                        + CLIENT_ID +"&scope=" + ACCESS_SCOPE + "&redirect_uri=" + CALLBACK_URL))
+                .build();
+    }
+
+    @GetMapping("/login/callback")
+    public void login(String code, String scope){
+        GithubAccessToken githubAccessToken = WebClient.create()
+                .post().uri(ACCESS_TOKEN_API_URL)
+                .accept(MediaType.APPLICATION_JSON)
+                .bodyValue(new GithubAccessTokenRequest(CLIENT_ID, CLIENT_SECRET, code))
+                .retrieve()
+                .bodyToMono(GithubAccessToken.class)
+                .blockOptional()
+                .orElseThrow(IllegalStateException::new);
+        log.info("githubAccessToken: {}", githubAccessToken);
+
+        GithubUser userInfo = WebClient.create()
+                .get().uri("https://api.github.com/user")
+                .accept(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + githubAccessToken.getAccessToken())
+                .retrieve()
+                .bodyToMono(GithubUser.class)
+                .blockOptional()
+                .orElseThrow(IllegalStateException::new);
+
+        log.info("authorization: {}", userInfo);
+    }
+
+
+
+
+}

--- a/BE/src/main/java/louie/hanse/issuetracker/oauth/OAuthService.java
+++ b/BE/src/main/java/louie/hanse/issuetracker/oauth/OAuthService.java
@@ -1,0 +1,8 @@
+package louie.hanse.issuetracker.oauth;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class OAuthService {
+
+}


### PR DESCRIPTION
- Cotroller에 Webclient 이용하여 임시 구현
- code 및 access_token 발급받아 사용자 정보 가져오기