### PR TITLE
feat: refresh 토큰 저장 및 access 토큰 재발급 기능 구현

### DIFF
--- a/BE/src/main/java/louie/hanse/issuetracker/controller/OAuthController.java
+++ b/BE/src/main/java/louie/hanse/issuetracker/controller/OAuthController.java
@@ -1,5 +1,6 @@
 package louie.hanse.issuetracker.controller;
 
+import com.auth0.jwt.exceptions.TokenExpiredException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import louie.hanse.issuetracker.jwt.JwtProvider;
@@ -13,13 +14,14 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.net.URI;
 
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-public class LoginController {
+public class OAuthController {
 
     private final MemberService memberService;
     private final OAuthService oAuthService;
@@ -42,8 +44,43 @@ public class LoginController {
         String accessToken = jwtProvider.createAccessToken(memberId);
         String refreshToken = jwtProvider.createRefreshToken(memberId);
 
+        memberService.updateRefreshToken(refreshToken, memberId);
+
         response.setHeader("Access-Token", accessToken);
         response.setHeader("Refresh-Token", refreshToken);
+
+        log.info("accessToken {}", accessToken);
+
+    }
+
+    @GetMapping("/reissue/access-token")
+    public void reissueAccessToken(HttpServletRequest request, HttpServletResponse response) {
+        String accessToken = request.getHeader("Access-Token");
+        String refreshToken = request.getHeader("Refresh-Token");
+
+        try {
+            jwtProvider.verifyAccessToken(accessToken);
+            response.setStatus(HttpStatus.FORBIDDEN.value());
+        } catch (TokenExpiredException e) {
+            jwtProvider.verifyRefreshToken(refreshToken);
+
+            Long accessTokenMemberId = jwtProvider.decodeMemberId(accessToken);
+            Long refreshTokenMemberId = jwtProvider.decodeMemberId(refreshToken);
+            if (accessTokenMemberId != refreshTokenMemberId) {
+                response.setStatus(HttpStatus.UNAUTHORIZED.value());
+                return;
+            }
+
+            String findRefreshToken = memberService.findRefreshTokenById(refreshTokenMemberId);
+            if (!findRefreshToken.equals(refreshToken)){
+                response.setStatus(HttpStatus.UNAUTHORIZED.value());
+                return;
+            }
+
+            String reissueAccessToken = jwtProvider.createAccessToken(refreshTokenMemberId);
+            response.setHeader("Access-Token",  reissueAccessToken);
+
+        }
     }
 
 }

--- a/BE/src/main/java/louie/hanse/issuetracker/domain/Member.java
+++ b/BE/src/main/java/louie/hanse/issuetracker/domain/Member.java
@@ -18,6 +18,7 @@ public class Member {
 
     private String socialId;
     private String avatarImageUrl;
+    private String refreshToken;
 
     public Member(String socialId, String avatarImageUrl) {
         this.socialId = socialId;
@@ -26,5 +27,13 @@ public class Member {
 
     public Long getId() {
         return id;
+    }
+
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+
+    public void changeRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
     }
 }

--- a/BE/src/main/java/louie/hanse/issuetracker/jwt/JwtProvider.java
+++ b/BE/src/main/java/louie/hanse/issuetracker/jwt/JwtProvider.java
@@ -12,8 +12,8 @@ import static javax.management.timer.Timer.ONE_WEEK;
 
 @Component
 public class JwtProvider {
-    public final String issuer;
-    public final Algorithm algorithm;
+    private final String issuer;
+    private final Algorithm algorithm;
 
     public JwtProvider(JwtProperties jwtProperties) {
         this.issuer = jwtProperties.getIssuer();
@@ -30,9 +30,22 @@ public class JwtProvider {
         return createToken("refreshToken", memberId, expiresAt);
     }
 
+    public void verifyAccessToken(String accessToken) {
+        verifyToken(accessToken, "accessToken");
+    }
+
+    public void verifyRefreshToken(String refreshToken) {
+        verifyToken(refreshToken, "refreshToken");
+    }
+
+    public Long decodeMemberId(String token) {
+        return JWT.decode(token)
+                .getClaim("memberId")
+                .asLong();
+    }
+
     private String createToken(String subject, Long memberId, Date expiresAt) {
         Date issuedAt = Date.from(Instant.now());
-
         return JWT.create()
                 .withIssuer(issuer)
                 .withSubject(subject)
@@ -44,4 +57,13 @@ public class JwtProvider {
 
                 .sign(algorithm);
     }
+
+    private void verifyToken(String token, String subject) {
+        JWT.require(algorithm)
+                .withIssuer(issuer)
+                .withSubject(subject)
+                .build()
+                .verify(token);
+    }
+
 }

--- a/BE/src/main/java/louie/hanse/issuetracker/service/MemberService.java
+++ b/BE/src/main/java/louie/hanse/issuetracker/service/MemberService.java
@@ -16,7 +16,6 @@ public class MemberService {
 
     @Transactional
     public Long login(GithubUser githubUser) {
-        //            TODO 커스텀 예외 추가하기
         Member member = memberRepository.findBySocialId(githubUser.getLogin())
             .orElse(null);
 
@@ -25,5 +24,21 @@ public class MemberService {
             memberRepository.save(member);
         }
         return member.getId();
+    }
+
+    public String findRefreshTokenById(Long id) {
+        return findByIdOrThrow(id).getRefreshToken();
+    }
+
+    @Transactional
+    public void updateRefreshToken(String refreshToken, Long id) {
+        Member member = findByIdOrThrow(id);
+        member.changeRefreshToken(refreshToken);
+    }
+
+    private Member findByIdOrThrow(Long id) {
+//            TODO 커스텀 예외 추가하기
+        return memberRepository.findById(id)
+                .orElseThrow(IllegalStateException::new);
     }
 }

--- a/BE/src/test/java/louie/hanse/issuetracker/IssueTrackerApplicationTests.java
+++ b/BE/src/test/java/louie/hanse/issuetracker/IssueTrackerApplicationTests.java
@@ -1,19 +1,36 @@
 package louie.hanse.issuetracker;
 
-import louie.hanse.issuetracker.repository.MemberRepository;
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import louie.hanse.issuetracker.jwt.JwtProperties;
+import louie.hanse.issuetracker.jwt.JwtProvider;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.time.Instant;
+import java.util.Date;
+
 @SpringBootTest
 class IssueTrackerApplicationTests {
 
-	@Autowired
-	MemberRepository memberRepository;
+    @Autowired
+    JwtProvider jwtProvider;
 
-	@Test
-	void contextLoads() {
-		memberRepository.existsBySocialId("dfae");
-	}
+    @Autowired
+    JwtProperties jwtProperties;
+
+    @Test
+    void contextLoads() {
+        Date expiresAt = Date.from(Instant.now().minusSeconds(12));
+
+        String jwt = JWT.create()
+                .withIssuer(jwtProperties.getIssuer())
+                .withExpiresAt(expiresAt)
+                .withSubject("accessToken")
+                .sign(Algorithm.HMAC256(jwtProperties.getSecretKey()));
+
+        jwtProvider.verifyAccessToken(jwt);
+    }
 
 }


### PR DESCRIPTION
### 📙 작업 내역

- [x] 클라이언트가 사용할 jwt토큰 생성 및 전송

### 📘 작업 유형

- 기능 추가